### PR TITLE
Fix repository key url and warning about apt loop

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 winehq_enable_32bit_arch: True
 
-winehq_apt_key_url: https://dl.winehq.org/wine-builds/Release.key
+winehq_apt_key_url: https://dl.winehq.org/wine-builds/winehq.key
 
 winehq_pkgs:
   - winehq-stable

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,12 +9,14 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
-        - xenial
+        - hirsute
+        - groovy
+        - focal
+        - bionic
     - name: Debian
       versions:
-        - jessie
-        - stretch
+        - buster
+        - bullseye
   galaxy_tags:
     - development
     - wine

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,9 +33,8 @@
 - name: Install winehq packages
   become: yes
   become_user: root
-  with_items: '{{winehq_pkgs}}'
   apt:
-    name: '{{item}}'
+    name: '{{winehq_pkgs}}'
     state: present
     update_cache: yes
     install_recommends: yes


### PR DESCRIPTION
## Repository key url

The WineHQ repository key was changed on 2018-12-19. If you downloaded and added the key before that time, you will need to download and add the new key and run sudo apt update to accept the repository changes.

See:
- https://wiki.winehq.org/Ubuntu
- https://wiki.winehq.org/Debian

## Warning about apt loop

When used with a loop: each package will be processed individually, it is much more efficient to pass the list directly to the name option.

See:
- https://docs.ansible.com/ansible/2.9/modules/apt_module.html#notes

